### PR TITLE
Fix out of bounds neighbor check

### DIFF
--- a/Pathfinding.cs
+++ b/Pathfinding.cs
@@ -225,7 +225,7 @@ namespace PathFinder
             }
 
             //Right
-            if (gridPosition.x + 1 <= _gridSys.GetWidth())
+            if (gridPosition.x + 1 < _gridSys.GetWidth())
             {
                 neighbors.Add(GetNode(gridPosition.x + 1, gridPosition.z + 0));
 
@@ -246,7 +246,7 @@ namespace PathFinder
             }
 
             //Up
-            if (gridPosition.z + 1 <= _gridSys.GetLength())
+            if (gridPosition.z + 1 < _gridSys.GetLength())
             {
                 neighbors.Add(GetNode(gridPosition.x + 0, gridPosition.z + 1));
             }


### PR DESCRIPTION
## Summary
- correct off-by-one checks in `GetNeighboringNodes`

## Testing
- `mcs -target:library -out:build.dll *.cs` *(fails: missing Unity dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a72c1dc14832bb4f90cdf9101abfc